### PR TITLE
Add Python email automation script

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,29 @@
+# Automatizador de envio de e-mails
 
+Este repositório contém um script simples em Python para automatizar o envio de e-mails utilizando SMTP.
+
+## Requisitos
+- Python 3.10 ou superior.
+- Um servidor SMTP (ex.: Gmail, Outlook) e as credenciais de acesso.
+
+## Configuração
+As informações do servidor e credenciais devem ser fornecidas por meio de variáveis de ambiente:
+
+- `EMAIL_HOST`: Host do servidor SMTP
+- `EMAIL_PORT`: Porta do servidor SMTP (padrão: `587`)
+- `EMAIL_USERNAME`: Usuário de autenticação
+- `EMAIL_PASSWORD`: Senha do usuário
+- `EMAIL_FROM`: Endereço de e-mail do remetente
+
+## Uso
+Execute o script `email_automation.py` informando os destinatários que devem receber a mensagem. O exemplo abaixo envia um e-mail de teste para um destinatário:
+
+```bash
+python email_automation.py
+```
+
+Altere a lista de `recipients` no final do arquivo para definir seus próprios destinatários.
+
+## Atenção
+- Não compartilhe suas credenciais de e-mail publicamente.
+- Verifique se o seu provedor de e-mail permite conexões SMTP e, se necessário, habilite senhas de apps ou configurações de acesso menos seguro.

--- a/email_automation.py
+++ b/email_automation.py
@@ -1,0 +1,45 @@
+import os
+import smtplib
+from email.mime.text import MIMEText
+from email.mime.multipart import MIMEMultipart
+
+
+def send_email(subject: str, body: str, recipients: list[str]):
+    """Send an email to a list of recipients using SMTP.
+
+    Configuration is taken from environment variables:
+        EMAIL_HOST: SMTP server host
+        EMAIL_PORT: SMTP server port (optional, defaults to 587)
+        EMAIL_USERNAME: username for login
+        EMAIL_PASSWORD: password for login
+        EMAIL_FROM: sender address
+    """
+    host = os.getenv("EMAIL_HOST")
+    port = int(os.getenv("EMAIL_PORT", "587"))
+    username = os.getenv("EMAIL_USERNAME")
+    password = os.getenv("EMAIL_PASSWORD")
+    sender = os.getenv("EMAIL_FROM")
+
+    if not all([host, username, password, sender]):
+        raise EnvironmentError("Missing required email configuration variables")
+
+    message = MIMEMultipart()
+    message["From"] = sender
+    message["To"] = ", ".join(recipients)
+    message["Subject"] = subject
+    message.attach(MIMEText(body, "plain"))
+
+    with smtplib.SMTP(host, port) as server:
+        server.starttls()
+        server.login(username, password)
+        server.sendmail(sender, recipients, message.as_string())
+
+
+if __name__ == "__main__":
+    # Example usage
+    recipients = ["example@example.com"]
+    send_email(
+        subject="Teste de envio",
+        body="Mensagem de teste enviada automaticamente.",
+        recipients=recipients,
+    )


### PR DESCRIPTION
## Summary
- implement `email_automation.py` to send emails via SMTP
- document usage and configuration in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6876e1dd10e483259f749681f29834ad