### PR TITLE
Add prototype generator and testing instructions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+__pycache__/
+*.pyc
+.venv/

--- a/README.md
+++ b/README.md
@@ -1,1 +1,105 @@
+# AdaptaNote - Gerador de Atividades Acessíveis
 
+AdaptaNote é uma plataforma pensada para educadores que precisam adaptar conteúdos curriculares para estudantes com deficiência intelectual, TEA, TDAH ou outras dificuldades de aprendizagem. A aplicação combina geração automática de conteúdo pedagógico com controles de acessibilidade, simplificando a produção de atividades e avaliações em questão de minutos.
+
+## Persona
+- **Quem usa:** Professores de sala regular, docentes de Atendimento Educacional Especializado (AEE) e terapeutas educacionais.
+- **Necessidade:** Criar rapidamente materiais adaptados com diferentes níveis de complexidade, mantendo alinhamento com o currículo.
+
+## Problema
+Educadores gastam horas procurando imagens, simplificando textos e formatando atividades acessíveis. O processo manual é exaustivo e dificulta a oferta de materiais personalizados para cada aluno.
+
+## Objetivo do Produto
+Permitir que o usuário informe um tema e receba um documento adaptado automaticamente, pronto para impressão ou uso digital, reduzindo drasticamente o tempo de preparação de atividades.
+
+## Funcionalidades Essenciais
+
+### 1. Geração de Conteúdo por Tema
+- **Entrada:** tema central (ex.: "Ciclo da Água", "Verbos no passado").
+- **Saída:** texto explicativo conciso + conjunto de questões base.
+- **Detalhes técnicos:**
+  - Motor de geração textual baseado em LLM com prompt ajustado para linguagem pedagógica.
+  - Controles de temperatura para manter consistência terminológica.
+
+### 2. Níveis de Adaptação
+- **Seleção do usuário:** Nível 1, 2 ou 3.
+- **Processamento:** pipeline de transformação que reescreve textos, ajusta tipos de questões e sugere recursos de apoio visual conforme o nível escolhido.
+- **Especificações de nível:**
+  - **Nível 1 – Simplificação leve:** textos curtos, questões objetivas, múltipla escolha com até 3 alternativas.
+  - **Nível 2 – Suporte visual amplo:** frases de 1-2 linhas, atividades de associação (ligar, circular), pareamento imagem-palavra.
+  - **Nível 3 – Adaptação profunda:** foco em imagens e vocabulário mínimo, respostas "sim/não" ou apontar figuras.
+
+### 3. Banco de Imagens Inteligente
+- **Automação:** seleção de pictogramas ou ilustrações simples para conceitos-chave.
+- **Fontes:** integração com bibliotecas livres (ex.: OpenMoji, TheNounProject) com filtros por estilo e direitos de uso.
+- **Entrega:** cada questão/alternativa relevante recebe imagem correspondente.
+
+### 4. Instruções Claras
+- **Opção do usuário:** checkbox "Incluir Instruções".
+- **Geração:**
+  - **Aluno:** comandos diretos ("Pinte a resposta certa.").
+  - **Aplicador/Professor:** orientações de mediação ("Leia a pergunta em voz alta, aponte para as imagens...").
+
+### 5. Exportação
+- **Formatos:** `.docx` e Google Docs.
+- **Implementação sugerida:**
+  - Uso de `python-docx` ou `docx-compose` para gerar arquivo local.
+  - Integração com Google Drive API para criar cópia editável.
+  - Garantia de preservação de layout (texto + imagens + instruções).
+
+## Arquitetura Proposta
+
+```text
+frontend/ (Next.js ou React + Tailwind)
+└─ components/ActivityPreview
+backend/ (FastAPI ou Django)
+└─ services/
+   ├─ content_generator.py   # prompts e pós-processamento
+   ├─ adaptation_engine.py   # aplica níveis de adaptação
+   ├─ image_retriever.py     # busca e seleciona imagens
+   ├─ export_service.py      # gera .docx ou Google Docs
+   └─ instructions_builder.py
+infra/
+└─ pipelines/llm_prompts.yaml
+```
+
+### Fluxo de dados
+1. Usuário envia tema + preferências.
+2. Backend chama `content_generator` para criar base textual.
+3. `adaptation_engine` ajusta o conteúdo conforme nível.
+4. `image_retriever` associa pictogramas.
+5. `instructions_builder` gera instruções opcionais.
+6. `export_service` compila tudo e entrega o documento.
+
+## Roadmap Inicial
+1. Prototipar interface de entrada de tema e visualização de prévia.
+2. Implementar prompts e regras de adaptação para os três níveis.
+3. Integrar banco de imagens livre com cache local.
+4. Construir exportação `.docx` + integração Google Docs.
+5. Testar com educadores e iterar com base no feedback.
+
+## Métricas de Sucesso
+- Tempo médio de criação de atividade < 5 minutos.
+- Taxa de reutilização de atividades > 60%.
+- Satisfação do usuário (NPS) >= 8.
+
+## Como testar rapidamente
+O repositório inclui um protótipo em linha de comando que permite gerar atividades fictícias de maneira
+rápida. Para instalar as dependências (apenas Python padrão) e executar:
+
+```bash
+python -m venv .venv
+source .venv/bin/activate
+pip install -e .  # opcional, apenas para uso em outros projetos
+python main.py "Ciclo da Água" --level 2
+```
+
+Também há testes automatizados básicos executáveis com `pytest`:
+
+```bash
+pip install pytest
+pytest
+```
+
+## Licença
+Projeto em desenvolvimento. Definir licença conforme diretrizes da organização.

--- a/adaptanote/__init__.py
+++ b/adaptanote/__init__.py
@@ -1,0 +1,5 @@
+"""AdaptaNote package."""
+
+from .generator import generate_activity, format_activity
+
+__all__ = ["generate_activity", "format_activity"]

--- a/adaptanote/generator.py
+++ b/adaptanote/generator.py
@@ -1,0 +1,184 @@
+"""Utility functions to generate adapted educational activities."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Dict, List
+
+
+@dataclass
+class Question:
+    """Represents an activity question."""
+
+    prompt: str
+    options: List[str]
+    answer: str
+    visuals: Dict[str, str]
+
+
+@dataclass
+class Instructions:
+    """Holds optional instructions for student and educator."""
+
+    student: str
+    educator: str
+
+
+@dataclass
+class Activity:
+    """Full activity payload."""
+
+    topic: str
+    level: int
+    summary: str
+    questions: List[Question]
+    instructions: Instructions | None
+
+
+def _base_summary(topic: str) -> str:
+    return (
+        f"O tema é {topic}. Vamos aprender as ideias principais de forma simples e prática."
+    )
+
+
+def _level_templates(level: int) -> Dict[str, str]:
+    if level == 1:
+        return {
+            "summary": (
+                "Explicação curta com palavras do dia a dia e foco em uma ideia principal."
+            ),
+            "question_type": "múltipla escolha",
+            "student_instruction": "Leia e marque a resposta correta.",
+            "educator_instruction": (
+                "Incentive o aluno a ler em voz alta e oferecer apoio apenas quando necessário."
+            ),
+        }
+    if level == 2:
+        return {
+            "summary": "Texto mínimo com apoio visual para cada conceito importante.",
+            "question_type": "associação",
+            "student_instruction": "Observe as figuras e una com uma linha a resposta.",
+            "educator_instruction": (
+                "Aponte para as imagens enquanto lê a pergunta, garantindo compreensão passo a passo."
+            ),
+        }
+    return {
+        "summary": "Linguagem objetiva usando poucas palavras e imagens claras.",
+        "question_type": "sim/não",
+        "student_instruction": "Aponte a imagem certa ou responda com sim ou não.",
+        "educator_instruction": (
+            "Mostre cada imagem, espere a indicação do aluno e confirme a resposta com gestos ou palavras simples."
+        ),
+    }
+
+
+def _generate_questions(topic: str, level: int) -> List[Question]:
+    visuals = {
+        "Sol": "imagem de um sol amarelo",
+        "Chuva": "imagem de nuvem com gotas",
+        "Planta": "ilustração de planta verde",
+        "Água": "ícone de gota d'água",
+    }
+
+    if level == 1:
+        return [
+            Question(
+                prompt=f"Qual opção está ligada ao tema {topic}?",
+                options=["Sol", "Chuva", "Planta"],
+                answer="Planta",
+                visuals={option: visuals.get(option, "") for option in ["Sol", "Chuva", "Planta"]},
+            ),
+            Question(
+                prompt="Qual palavra mostra algo que o tema usa?",
+                options=["Água", "Bola", "Gato"],
+                answer="Água",
+                visuals={"Água": visuals.get("Água", "")},
+            ),
+        ]
+
+    if level == 2:
+        return [
+            Question(
+                prompt=f"Ligue a palavra ao desenho sobre {topic}.",
+                options=["Planta", "Sol", "Água"],
+                answer="Planta",
+                visuals={option: visuals.get(option, "") for option in ["Planta", "Sol", "Água"]},
+            ),
+            Question(
+                prompt="Circule a imagem que ajuda o tema.",
+                options=["Sol", "Chuva"],
+                answer="Sol",
+                visuals={option: visuals.get(option, "") for option in ["Sol", "Chuva"]},
+            ),
+        ]
+
+    return [
+        Question(
+            prompt=f"{topic}. Sol?",
+            options=["Sim", "Não"],
+            answer="Sim",
+            visuals={"Sim": visuals.get("Sol", "imagem de um sol"), "Não": "X vermelho"},
+        ),
+        Question(
+            prompt=f"{topic}. Água?",
+            options=["Sim", "Não"],
+            answer="Sim",
+            visuals={"Sim": visuals.get("Água", "ícone de água"), "Não": "X vermelho"},
+        ),
+    ]
+
+
+def generate_activity(topic: str, level: int, include_instructions: bool = True) -> Activity:
+    """Generate an adapted activity for the given topic and level."""
+    if not topic or not topic.strip():
+        raise ValueError("topic must not be empty")
+
+    if level not in {1, 2, 3}:
+        raise ValueError("level must be 1, 2, or 3")
+
+    templates = _level_templates(level)
+
+    instructions = None
+    if include_instructions:
+        instructions = Instructions(
+            student=templates["student_instruction"],
+            educator=templates["educator_instruction"],
+        )
+
+    summary = f"{_base_summary(topic)} {templates['summary']}"
+
+    return Activity(
+        topic=topic,
+        level=level,
+        summary=summary,
+        questions=_generate_questions(topic, level),
+        instructions=instructions,
+    )
+
+
+def format_activity(activity: Activity) -> str:
+    """Create a human-readable representation of an activity."""
+    lines: List[str] = []
+    lines.append(f"Tema: {activity.topic}")
+    lines.append(f"Nível: {activity.level}")
+    lines.append("")
+    lines.append("Resumo:")
+    lines.append(activity.summary)
+    lines.append("")
+
+    for index, question in enumerate(activity.questions, start=1):
+        lines.append(f"Pergunta {index}: {question.prompt}")
+        for option in question.options:
+            visual = question.visuals.get(option, "")
+            visual_text = f" (visual: {visual})" if visual else ""
+            lines.append(f"  - {option}{visual_text}")
+        lines.append(f"Resposta sugerida: {question.answer}")
+        lines.append("")
+
+    if activity.instructions:
+        lines.append("Instruções para o aluno:")
+        lines.append(activity.instructions.student)
+        lines.append("")
+        lines.append("Instruções para o aplicador/professor:")
+        lines.append(activity.instructions.educator)
+
+    return "\n".join(lines)

--- a/main.py
+++ b/main.py
@@ -1,0 +1,39 @@
+"""Simple CLI to generate AdaptaNote activities."""
+from __future__ import annotations
+
+import argparse
+from adaptanote import format_activity, generate_activity
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Gerador simples de atividades adaptadas AdaptaNote",
+    )
+    parser.add_argument("topic", help="Tema central da atividade")
+    parser.add_argument(
+        "--level",
+        type=int,
+        default=1,
+        choices=[1, 2, 3],
+        help="Nível de adaptação (1, 2 ou 3)",
+    )
+    parser.add_argument(
+        "--no-instructions",
+        action="store_true",
+        help="Não incluir instruções para aluno e professor",
+    )
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+    activity = generate_activity(
+        topic=args.topic,
+        level=args.level,
+        include_instructions=not args.no_instructions,
+    )
+    print(format_activity(activity))
+
+
+if __name__ == "__main__":
+    main()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,11 @@
+[project]
+name = "adaptanote"
+version = "0.1.0"
+description = "Protótipo simples do gerador de atividades acessíveis"
+readme = "README.md"
+requires-python = ">=3.9"
+authors = [{ name = "AdaptaNote" }]
+
+[build-system]
+requires = ["setuptools>=61.0"]
+build-backend = "setuptools.build_meta"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,7 @@
+"""Test configuration."""
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))

--- a/tests/test_generator.py
+++ b/tests/test_generator.py
@@ -1,0 +1,26 @@
+"""Tests for the AdaptaNote generator."""
+from adaptanote.generator import generate_activity, format_activity
+
+
+def test_generate_activity_level_range():
+    activity = generate_activity("Ciclo da Água", 1)
+    assert activity.topic == "Ciclo da Água"
+    assert activity.level == 1
+    assert len(activity.questions) == 2
+    assert activity.instructions is not None
+
+
+def test_generate_activity_invalid_level():
+    try:
+        generate_activity("Ciclo da Água", 4)
+    except ValueError as exc:
+        assert "level" in str(exc)
+    else:
+        raise AssertionError("Expected ValueError for invalid level")
+
+
+def test_format_activity_includes_instructions():
+    activity = generate_activity("Fotossíntese", 2, include_instructions=True)
+    formatted = format_activity(activity)
+    assert "Instruções para o aluno" in formatted
+    assert "Fotossíntese" in formatted


### PR DESCRIPTION
## Summary
- add a simple AdaptaNote activity generator module and CLI prototype
- provide packaging metadata, ignore cache files, and document quick testing instructions
- cover the generator with basic pytest checks

## Testing
- pytest

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690397c9e6cc8325b270403a06c1a064)